### PR TITLE
Restore original minimal design, remove system.css

### DIFF
--- a/public/assets/styles/main.css
+++ b/public/assets/styles/main.css
@@ -1,147 +1,50 @@
-/* Custom styles for system.css integration */
 body {
-    background-color: #c0c0c0;
-    padding: 0;
-    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
+        "Helvetica Neue", sans-serif;
 }
-
-.window-pane {
-    padding: 20px;
+.site {
+    box-sizing: border-box;
+    min-width: 200px;
+    max-width: 700px;
+    margin: 0 auto;
+    padding: 45px;
 }
-
-.post-header {
-    margin-bottom: 30px;
-}
-
 .post-meta {
-    margin-top: 15px;
-    margin-bottom: 15px;
+    margin-top: 40px;
+    margin-bottom: 70px;
 }
-
 .post-meta span.post-date {
-    color: #666;
-    font-size: 0.9em;
+    opacity: 0.5;
+}
+.post-meta h1.post-title {
+    margin-top: 0;
+    border-bottom: none;
+}
+footer {
+    margin-top: 70px;
+}
+header.intro h1 {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+.post h3 {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+.post small {
+    opacity: 0.5;
 }
 
-.post-tags {
-    margin-top: 8px;
+code,
+pre {
+    font-family: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter",
+        "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New",
+        Courier, monospace;
 }
 
-.post-tags .tag {
-    display: inline-block;
-    background: #000;
-    color: #fff;
-    padding: 2px 8px;
-    margin-right: 5px;
-    font-size: 0.85em;
-    border-radius: 2px;
-}
-
-.content {
-    line-height: 1.6;
-    margin: 20px 0;
-}
-
-.content h1,
-.content h2,
-.content h3,
-.content h4,
-.content h5,
-.content h6 {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-}
-
-.content p {
-    margin-bottom: 1em;
-}
-
-.content img {
-    max-width: 100%;
-    height: auto;
-}
-
-.content code {
-    background-color: #f0f0f0;
-    padding: 2px 6px;
-    border-radius: 3px;
-    font-family: "Courier New", Courier, monospace;
-}
-
-.content pre {
-    background-color: #f5f5f5;
-    padding: 15px;
-    overflow-x: auto;
-    border: 1px solid #000;
-    margin: 1em 0;
-}
-
-.content pre code {
-    background-color: transparent;
-    padding: 0;
-}
-
-.content blockquote {
-    border-left: 3px solid #000;
-    margin-left: 0;
-    padding-left: 15px;
-    color: #666;
-}
-
-.content table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 1em 0;
-}
-
-.content table th,
-.content table td {
-    border: 1px solid #000;
-    padding: 8px;
-    text-align: left;
-}
-
-.content table th {
-    background-color: #000;
-    color: #fff;
-}
-
-.content ul,
-.content ol {
-    margin-bottom: 1em;
-    padding-left: 2em;
-}
-
-.content a {
-    color: #0000ee;
-    text-decoration: underline;
-}
-
-.content a:visited {
-    color: #551a8b;
-}
-
-/* Responsive adjustments */
-@media (max-width: 820px) {
-    .window {
-        margin: 10px !important;
-    }
-
-    .window-pane {
+@media (max-width: 767px) {
+    .site {
         padding: 15px;
-    }
-}
-
-@media (max-width: 480px) {
-    .window {
-        margin: 5px !important;
-    }
-
-    .window-pane {
-        padding: 10px;
-    }
-
-    .title-bar h1.title {
-        font-size: 0.9em;
     }
 }

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -8,50 +8,35 @@ const homepage = posts => `
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="${config.blogDescription}" />
-        <link rel="stylesheet" href="https://unpkg.com/@sakun/system.css" />
+        <link rel="stylesheet" href="./assets/styles/markdown-body.css">
+        <link rel="stylesheet" href="./assets/styles/highlights.css">
         <link rel="stylesheet" href="./assets/styles/main.css">
         <title>${config.blogName}</title>
     </head>
     <body>
-        <div class="window" style="margin: 20px auto; max-width: 800px;">
-            <div class="title-bar">
-                <button aria-label="Close" class="close"></button>
-                <h1 class="title">${config.blogName}</h1>
-                <button aria-label="Resize" class="resize"></button>
+        <div class="site">
+            <header class="intro">
+                <h1>${config.blogName}</h1>
+                <p>${config.blogDescription}</p>
+                <p>Written by <a href="${config.authorWebsite}">${config.authorName}</a>, ${config.authorDescription}</p>
+            </header>
+
+            <div class="posts">
+                ${posts
+                  .filter(post => !post.attributes.draft)
+                  .map(
+                    post => `<div class="post">
+                      <small>${post.attributes.date ? post.attributes.date : ''}</small>
+                      <h3><a href="./${post.path}">${post.attributes.title}</a></h3>
+                      <p>${post.attributes.description}</p>
+                    </div>`
+                  )
+                  .join("")}
             </div>
-            <div class="separator"></div>
 
-            <div class="window-pane">
-                <div class="field-row" style="justify-content: center; margin-bottom: 20px;">
-                    <p style="text-align: center;">
-                        ${config.blogDescription}<br/>
-                        Written by <a href="${config.authorWebsite}">${config.authorName}</a>, ${config.authorDescription}
-                    </p>
-                </div>
-
-                <div class="separator"></div>
-
-                <div class="posts">
-                    ${posts
-                      .filter(post => !post.attributes.draft)
-                      .map(
-                        post => `<div class="post" style="margin-bottom: 20px; padding: 10px; border: 1px solid #000;">
-                          <div class="field-row">
-                            <small style="color: #666;">${post.attributes.date ? post.attributes.date : ''}</small>
-                          </div>
-                          <h3 style="margin: 5px 0;"><a href="./${post.path}">${post.attributes.title}</a></h3>
-                          <p style="margin: 5px 0;">${post.attributes.description}</p>
-                          ${post.attributes.tags ? `<div class="post-tags">${post.attributes.tags.map(tag => `<span class="tag">${tag}</span>`).join(' ')}</div>` : ''}
-                        </div>`
-                      )
-                      .join("")}
-                </div>
-
-                <div class="separator"></div>
-                <footer style="text-align: center; padding: 10px 0;">
-                    <p>© ${new Date().getFullYear()} ${config.authorName}</p>
-                </footer>
-            </div>
+            <footer>
+                <p>© ${new Date().getFullYear()} ${config.authorName}</p>
+            </footer>
         </div>
     </body>
 </html>

--- a/src/posts.js
+++ b/src/posts.js
@@ -10,38 +10,26 @@ const posthtml = data => `
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="${data.attributes.description}" />
-        <link rel="stylesheet" href="https://unpkg.com/@sakun/system.css" />
+        <link rel="stylesheet" href="../assets/styles/markdown-body.css">
         <link rel="stylesheet" href="../assets/styles/highlights.css">
         <link rel="stylesheet" href="../assets/styles/main.css">
         <title>${data.attributes.title} - ${config.blogName}</title>
     </head>
     <body>
-        <div class="window" style="margin: 20px auto; max-width: 800px;">
-            <div class="title-bar">
-                <button aria-label="Close" class="close"></button>
-                <h1 class="title">${data.attributes.title}</h1>
-                <button aria-label="Resize" class="resize"></button>
+        <div class="site">
+            <a href="/">← Back to Home</a>
+            <div class="post-meta">
+                <h1 class="post-title">${data.attributes.title}</h1>
+                <span class="post-date" ${!data.attributes.date ? 'style="display:none"' : ''}>${data.attributes.date}</span>
             </div>
-            <div class="separator"></div>
 
-            <div class="window-pane">
-                <div class="post-header">
-                    <a href="/" class="btn">← Back to Home</a>
-                    <div class="post-meta">
-                        <span class="post-date" ${!data.attributes.date ? 'style="display:none"' : ''}>${data.attributes.date}</span>
-                        ${data.attributes.tags ? `<div class="post-tags">${data.attributes.tags.map(tag => `<span class="tag">${tag}</span>`).join(' ')}</div>` : ''}
-                    </div>
-                </div>
-
-                <div class="content">
-                    ${data.body}
-                </div>
-
-                <div class="separator"></div>
-                <footer style="text-align: center; padding: 10px 0;">
-                    <p>© ${new Date().getFullYear()} ${config.authorName}</p>
-                </footer>
+            <div class="markdown-body">
+                ${data.body}
             </div>
+
+            <footer>
+                <p>© ${new Date().getFullYear()} ${config.authorName}</p>
+            </footer>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Replace Windows 98-style system.css UI with the original clean, minimal design.

Changes:
- Revert main.css to original simple styles from commit 330ad5a
- Update homepage.js to use clean layout instead of window-based UI
- Update posts.js to use minimal design without system.css components
- Remove external dependency on @sakun/system.css